### PR TITLE
Excluding "land" points

### DIFF
--- a/Model.R
+++ b/Model.R
@@ -7,6 +7,10 @@ assessmentYear <- 2021
 #load(file.path("Output", "StationSamples.RData"))
 stationSamples <- fread(file.path("Data", "StationSamples.csv.gz"))
 
+# Sampling points which were found to be "on land" using a negative buffer do not have a ClusterID
+# exclude them from the further analysis
+stationSamples <- stationSamples[!is.na(ClusterID),]
+
 stationSamples <- stationSamples[, .(
   DataSourceID,
   SeaRegionID,


### PR DESCRIPTION
Added a negative buffer to the function **classify_locations_into_clusters()** (default 5km)

The negative "inland" buffer polygon is smaller than the original polygon. Therefore points intersecting are at a greater distance from the coastline than the buffer distance. These points are excluded from the cluster analysis and do not get assigned a ClusterID. This allows us to exclude them from further calculations. 

This is a not very nice fix to a problem which really should be solved somewhere else by determining which stations are marine and which are not. The results are obviously very dependent on the resolution of the shapefile which defines the coastline.

![snapshot](https://github.com/ices-tools-dev/OceanCSI/assets/11943443/752a9fdb-19cb-4620-b583-24c152227414)
